### PR TITLE
Map Page내의 작은 부분 수정

### DIFF
--- a/client/src/hooks/useShopList.ts
+++ b/client/src/hooks/useShopList.ts
@@ -3,12 +3,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../modules';
 import { Shop } from '../types';
 
-const boongImg =
-  'https://media.vlpt.us/images/dolarge/post/9df7aa9c-5827-4928-8711-25763612cc5f/%EB%B6%95%EC%96%B4.png';
-const hoImg =
-  'https://media.vlpt.us/images/dolarge/post/18a0d072-1987-44e6-a8dc-74fb5d40a337/%ED%98%B8%EB%96%A1.png';
-const taImg =
-  'https://media.vlpt.us/images/dolarge/post/9afdecdf-2a14-4079-9c06-487d657c6c7e/%ED%83%80%EC%BD%94.png';
+import { BOONG_IMG, HO_IMG, TA_IMG, MARKER } from '../styles/img';
 
 const useShopList = (window: any, ref: any) => {
   const { kakao } = window;
@@ -79,20 +74,19 @@ const useShopList = (window: any, ref: any) => {
       let imageSize: any;
       switch (type) {
         case 'boong':
-          imageSrc = boongImg;
+          imageSrc = BOONG_IMG;
           imageSize = new kakao.maps.Size(35, 24);
           break;
         case 'ho':
-          imageSrc = hoImg;
+          imageSrc = HO_IMG;
           imageSize = new kakao.maps.Size(30, 30);
           break;
         case 'ta':
-          imageSrc = taImg;
+          imageSrc = TA_IMG;
           imageSize = new kakao.maps.Size(30, 30);
           break;
         default:
-          imageSrc =
-            'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
+          imageSrc = MARKER;
           imageSize = new kakao.maps.Size(24, 35);
       }
       return [imageSrc, imageSize];

--- a/client/src/hooks/useShopList.ts
+++ b/client/src/hooks/useShopList.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../modules';
 import { Shop } from '../types';
-
 import { BOONG_IMG, HO_IMG, TA_IMG, MARKER } from '../styles/img';
 
 const useShopList = (window: any, ref: any) => {
@@ -97,8 +96,37 @@ const useShopList = (window: any, ref: any) => {
   const makeInfoWindow = useCallback(
     (shop: any) => {
       // 마커에 커서가 오버됐을 때 마커 위에 표시할 인포윈도우를 생성합니다
-      const iwContent = `<div class="marker-info"><p class="name">${shop.name}</p><p class="address">${shop.address}</p><p class="time">${shop.openTime}-${shop.closeTime}</p></div>`; // 인포윈도우에 표출될 내용으로 HTML 문자열이나 document element가 가능합니다
-
+      const iwContent = `
+        <div style="
+          background-color: #e8ded8;
+          background-size: 100%;
+          padding: 1em;
+          width: 148px;
+          height: 100px;
+          text-align: center;
+          border: 3px solid #8e8986;
+          color: #8e8986;
+          box-sizing: border-box;
+          color: #5d5959;
+          display:flex;
+          flex-direction:column;
+          align-items:center;
+          justify-content:center
+          ">
+          <p style="
+            font-size:1rem;" >
+            ${shop.name}
+          </p>
+          <p style="
+            font-size:12px;
+            margin:5px 0">
+            ${shop.address}
+          </p>
+          <p style="
+            font-size:11px;">
+            ${shop.openTime}-${shop.closeTime}
+          </p>
+        </div>`;
       // 인포윈도우를 생성합니다
       const infowindow = new kakao.maps.InfoWindow({
         content: iwContent,

--- a/client/src/styles/img.ts
+++ b/client/src/styles/img.ts
@@ -6,3 +6,5 @@ export const TA_IMG =
   'https://media.vlpt.us/images/dolarge/post/9afdecdf-2a14-4079-9c06-487d657c6c7e/%ED%83%80%EC%BD%94.png';
 export const ALL_IMG =
   'https://media.vlpt.us/images/dolarge/post/aa3ea81d-4b5a-431a-9f22-090bdbea1a71/all.png';
+export const MARKER =
+  'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';


### PR DESCRIPTION
## 요약
infowindow css 수정 및 hooks파일 내부에 있던 url을 상수로 만들어 관리하고 사용

## 작업 내용
> 작업 내용 상세
- [x] 인포윈도우에 적용되는 스타일을 html태그에 직접 스타일설정으로 작성해줌
- [x]  marker의 이미지주소를 상수로 만들어 관리
- [x] 상수로 이름지어진 이미지주소를 import해서 사용 

## 특이 사항
scss를 styled-componenet로 마이그레이션 하면서 인포윈도우에 적용되던 css가 사라졌음
그리고 스타일을 html태그에 직접 설정해주는 방식으로 해결!

